### PR TITLE
Add missing keyword and preprocessor tokens

### DIFF
--- a/cpp/raw/test.txt
+++ b/cpp/raw/test.txt
@@ -47,7 +47,8 @@ __STDC_MB_MIGHT_NEQ_WC__
 __STDC_VERSION__
 __STDC__
 __TIME__
-__VA_AR_GS__
+__VA_ARGS__
+__VA_OPT__
 __cplusplus
 __has_include
 __has_cpp_attribute
@@ -73,6 +74,7 @@ const
 const_cast
 consteval
 constexpr
+constinit
 continue
 decltype
 default
@@ -255,7 +257,8 @@ a__STDC_MB_MIGHT_NEQ_WC__
 a__STDC_VERSION__
 a__STDC__
 a__TIME__
-a__VA_AR_GS__
+a__VA_ARGS__
+a__VA_OPT__
 a__cplusplus
 a__has_include
 #definea
@@ -288,7 +291,7 @@ __STDC_MB_MIGHT_NEQ_WC__a
 __STDC_VERSION__a
 __STDC__a
 __TIME__a
-__VA_AR_GS__a
+__VA_ARGS__a
 __cplusplusa
 __has_includea
 
@@ -313,6 +316,7 @@ aconst
 aconst_cast
 aconstexpr
 aconsteval
+aconstinit
 acontinue
 adecltype
 adefault

--- a/cpp/raw/test.txt.faceup
+++ b/cpp/raw/test.txt.faceup
@@ -47,7 +47,8 @@
 «p:__STDC_VERSION__»
 «p:__STDC__»
 «p:__TIME__»
-«p:__VA_AR_GS__»
+«p:__VA_ARGS__»
+«p:__VA_OPT__»
 «p:__cplusplus»
 «p:__has_include»
 «p:__has_cpp_attribute»
@@ -73,6 +74,7 @@
 «k:const_cast»
 «k:consteval»
 «k:constexpr»
+«k:constinit»
 «k:continue»
 «k:decltype»
 «k:default»
@@ -255,7 +257,8 @@ a«p:__STDC_MB_MIGHT_NEQ_WC__»
 a«p:__STDC_VERSION__»
 a«p:__STDC__»
 a«p:__TIME__»
-a«p:__VA_AR_GS__»
+a«p:__VA_ARGS__»
+a«p:__VA_OPT__»
 a«p:__cplusplus»
 a«p:__has_include»
 «p:#define»a
@@ -288,7 +291,7 @@ a«p:__has_include»
 «p:__STDC_VERSION__»a
 «p:__STDC__»a
 «p:__TIME__»a
-«p:__VA_AR_GS__»a
+«p:__VA_ARGS__»a
 «p:__cplusplus»a
 «p:__has_include»a
 
@@ -313,6 +316,7 @@ aconst
 aconst_cast
 aconstexpr
 aconsteval
+aconstinit
 acontinue
 adecltype
 adefault

--- a/modern-cpp-font-lock.el
+++ b/modern-cpp-font-lock.el
@@ -74,7 +74,7 @@ http://en.cppreference.com/w/cpp/language/types"
 
 (defcustom modern-c++-preprocessors
   (eval-when-compile
-    (sort '("#define" "#defined" "#elif" "#else" "#endif" "#error" "#if" "#ifdef" "#ifndef" "#include" "#line" "#pragma STDC CX_LIMITED_RANGE" "#pragma STDC FENV_ACCESS" "#pragma STDC FP_CONTRACT" "#pragma once" "#pragma pack" "#pragma" "#undef" "_Pragma" "__DATE__" "__FILE__" "__LINE__" "__STDCPP_STRICT_POINTER_SAFETY__" "__STDCPP_THREADS__" "__STDC_HOSTED__" "__STDC_ISO_10646__" "__STDC_MB_MIGHT_NEQ_WC__" "__STDC_VERSION__" "__STDC__" "__TIME__" "__VA_AR_GS__" "__cplusplus" "__has_include" "__has_cpp_attribute")
+    (sort '("#define" "#defined" "#elif" "#else" "#endif" "#error" "#if" "#ifdef" "#ifndef" "#include" "#line" "#pragma STDC CX_LIMITED_RANGE" "#pragma STDC FENV_ACCESS" "#pragma STDC FP_CONTRACT" "#pragma once" "#pragma pack" "#pragma" "#undef" "_Pragma" "__DATE__" "__FILE__" "__LINE__" "__STDCPP_STRICT_POINTER_SAFETY__" "__STDCPP_THREADS__" "__STDC_HOSTED__" "__STDC_ISO_10646__" "__STDC_MB_MIGHT_NEQ_WC__" "__STDC_VERSION__" "__STDC__" "__TIME__" "__VA_ARGS__" "__VA_OPT__" "__cplusplus" "__has_include" "__has_cpp_attribute")
           'modern-c++-string-lenght>))
   "List of C++ preprocessor words. See doc:
 http://en.cppreference.com/w/cpp/keyword and
@@ -85,7 +85,7 @@ http://en.cppreference.com/w/cpp/preprocessor"
 
 (defcustom modern-c++-keywords
   (eval-when-compile
-    (sort '("alignas" "alignof" "and" "and_eq" "asm" "atomic_cancel" "atomic_commit" "atomic_noexcept" "audit" "auto" "axiom" "bitand" "bitor" "break" "case" "catch" "class" "compl" "concept" "const" "constexpr" "consteval" "const_cast" "continue" "co_await" "co_return" "co_yield" "decltype" "default" "delete" "do" "dynamic_cast" "else" "enum" "explicit" "export" "extern" "final" "for" "friend" "goto" "if" "import" "inline" "module" "mutable" "namespace" "new" "noexcept" "not" "not_eq" "operator" "or" "or_eq" "override" "private" "protected" "public" "register" "reinterpret_cast" "requires" "return" "sizeof" "static" "static_assert" "static_cast" "struct" "switch" "synchronized" "template" "this" "thread_local" "throw" "transaction_safe" "transaction_safe_dynamic" "try" "typedef" "typeid" "typename" "union" "using" "virtual" "volatile" "while" "xor" "xor_eq")
+    (sort '("alignas" "alignof" "and" "and_eq" "asm" "atomic_cancel" "atomic_commit" "atomic_noexcept" "audit" "auto" "axiom" "bitand" "bitor" "break" "case" "catch" "class" "compl" "concept" "const" "constexpr" "consteval" "constinit" "const_cast" "continue" "co_await" "co_return" "co_yield" "decltype" "default" "delete" "do" "dynamic_cast" "else" "enum" "explicit" "export" "extern" "final" "for" "friend" "goto" "if" "import" "inline" "module" "mutable" "namespace" "new" "noexcept" "not" "not_eq" "operator" "or" "or_eq" "override" "private" "protected" "public" "register" "reinterpret_cast" "requires" "return" "sizeof" "static" "static_assert" "static_cast" "struct" "switch" "synchronized" "template" "this" "thread_local" "throw" "transaction_safe" "transaction_safe_dynamic" "try" "typedef" "typeid" "typename" "union" "using" "virtual" "volatile" "while" "xor" "xor_eq")
           'modern-c++-string-lenght>))
   "List of C++ keywords. See doc:
 http://en.cppreference.com/w/cpp/keyword"


### PR DESCRIPTION
`constinit` and `__VA_OPT__` are added.

I think `__VA_AR_GS__` is misspelled